### PR TITLE
Fix for `PRODENV` being set incorrectly in `setup.sh`

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 
-PRODENV=$(cd -P -- "$(dirname -- "$0")" && pwd -P)
+declare -r SCRIPT_NAME=$(readlink -f ${BASH_SOURCE[0]})
+PRODENV=$(cd -P -- "$(dirname -- $SCRIPT_NAME)" && pwd -P)
 # custom prodenv software gets precedence
 PATH="${PRODENV}/bin:${PRODENV}/tools/bin:$PATH"
 PYTHONDONTWRITEBYTECODE=1


### PR DESCRIPTION
When running `source setup.sh` on some systems, the `PRODENV` variable is set instead to the folder where `bash` exists, e.g. `/bin`. This appears to be because the `$0` is set to `/bin/bash` when sourcing the script (as opposed to running the script via `bash setup.sh`). I was experiencing this issue using a terminal on the NERSC Jupyter server.

See more, e.g., in this Stack Overflow post: https://stackoverflow.com/questions/21792176/0-doesnt-work-when-i-source-a-bash-script

I took the solution from one of the answers, and have tested it to confirm that `PRODENV` is set to location of the script when sourcing through the terminal on the Jupyter server, as well as ssh-ing into perlmutter directly.